### PR TITLE
Updating bonecp version, adding hibernate-validator as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.jolbox</groupId>
             <artifactId>bonecp</artifactId>
-            <version>0.7.1.RELEASE</version>
+            <version>0.8.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -125,7 +125,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>4.3.0.Final</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>


### PR DESCRIPTION
This is what I had to change to get it running in my project:
- bonecp 0.7.1 does not work with current guava version: http://stackoverflow.com/questions/18948046/error-trying-to-configure-tomcat-global-jndi-connectionpool-with-bonecp
- hibernate-validator is needed at runtime: http://stackoverflow.com/questions/3982950/javax-validation-validationexception-unable-to-find-default-provider
