### PR TITLE
Updated org.reflections version for java8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.zalando</groupId>
     <artifactId>zalando-sprocwrapper</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
     <name>Stored Procedure Wrapper</name>
     <description>Library to make PostgreSQL stored procedures available through simple Java "*SProcService" interfaces including automatic object serialization and deserialization (using typemapper and convention-over-configuration). Supports sharding, advisory locking, statement timeouts and PostgreSQL types such as enums and hstore.</description>
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/de/zalando/sprocwrapper/globalobjecttransformer/GlobalObjectTransformerLoader.java
+++ b/src/main/java/de/zalando/sprocwrapper/globalobjecttransformer/GlobalObjectTransformerLoader.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.reflections.Reflections;
 
+import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 
 import org.reflections.util.ClasspathHelper;
@@ -102,7 +103,7 @@ public class GlobalObjectTransformerLoader {
         final Reflections reflections = new Reflections(new ConfigurationBuilder().filterInputsBy(
                     new FilterBuilder.Include(FilterBuilder.prefix(myNameSpaceToScan))).setUrls(
                     ClasspathHelper.forPackage(myNameSpaceToScan)).setScanners(new TypeAnnotationsScanner()
-                        .filterResultsBy(filter)));
+                        .filterResultsBy(filter), new SubTypesScanner()));
         final Set<Class<?>> objectMapper = reflections.getTypesAnnotatedWith(GlobalObjectMapper.class);
 
         return objectMapper;

--- a/src/main/java/de/zalando/sprocwrapper/globalvaluetransformer/GlobalValueTransformerLoader.java
+++ b/src/main/java/de/zalando/sprocwrapper/globalvaluetransformer/GlobalValueTransformerLoader.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.reflections.Reflections;
 
+import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 
 import org.reflections.util.ClasspathHelper;
@@ -61,7 +62,7 @@ public class GlobalValueTransformerLoader {
                 final Reflections reflections = new Reflections(new ConfigurationBuilder().filterInputsBy(
                             new FilterBuilder.Include(FilterBuilder.prefix(myNameSpaceToScan))).setUrls(
                             ClasspathHelper.forPackage(myNameSpaceToScan)).setScanners(new TypeAnnotationsScanner()
-                                .filterResultsBy(filter)));
+                                .filterResultsBy(filter), new SubTypesScanner()));
                 final Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(
                         GlobalValueTransformer.class);
                 for (final Class<?> foundGlobalValueTransformer : typesAnnotatedWith) {


### PR DESCRIPTION
The changes concern updates in the org.reflections/javassist libraries that have incompatibilities with Java 8, e.g.
https://code.google.com/p/reflections/issues/detail?id=169
and
http://stackoverflow.com/a/23625762/2711488
