### PR TITLE
Add additional badges and use generic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ SProcWrapper
 ============
 
 [![Build Status](https://travis-ci.org/zalando-incubator/java-sproc-wrapper.svg)](https://travis-ci.org/zalando/java-sproc-wrapper) [![Coverage Status](https://coveralls.io/repos/zalando-incubator/java-sproc-wrapper/badge.svg)](https://coveralls.io/r/zalando-incubator/java-sproc-wrapper)
+[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/de.zalando/zalando-sprocwrapper/badge.svg)](http://www.javadoc.io/doc/de.zalando/zalando-sprocwrapper)
+[![Maven Central](https://img.shields.io/maven-central/v/de.zalando/zalando-sprocwrapper.svg)](https://maven-badges.herokuapp.com/maven-central/de.zalando/zalando-sprocwrapper)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/zalando/problem-spring-web/master/LICENSE)
+
+
 
 Library to make PostgreSQL stored procedures(SProcs) available through simple Java "SProcService" interfaces including automatic object serialization and deserialization (using typemapper and convention-over-configuration).
 
@@ -15,7 +20,7 @@ To use SProcWrapper, add the following lines to your pom.xml:
 <dependency>
     <groupId>de.zalando</groupId>
     <artifactId>zalando-sprocwrapper</artifactId>
-    <version>1.5.1</version>
+    <version>${zalando-sprocwrapper.version}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
* Added badges for JavaDoc, Maven Central and the License
* Changed the version in the dependency inclusion example to use `${zalando-sprocwrapper.version}` instead a hardcoded version number