### PR TITLE
Use long for typeId

### DIFF
--- a/src/main/java/de/zalando/typemapper/core/TypeMapper.java
+++ b/src/main/java/de/zalando/typemapper/core/TypeMapper.java
@@ -71,7 +71,7 @@ public class TypeMapper<ITEM> implements RowMapper<ITEM> {
         final ResultTree tree = new ResultTree();
 
         for (int i = 1; i <= rsMetaData.getColumnCount(); i++) {
-            final int typeId = pgSet.getColumnOID(i);
+            final long typeId = pgSet.getColumnOID(i);
             DbResultNode node = null;
 
             final Object obj = pgSet.getObject(i);

--- a/src/main/java/de/zalando/typemapper/core/db/DbFunctionRegister.java
+++ b/src/main/java/de/zalando/typemapper/core/db/DbFunctionRegister.java
@@ -66,9 +66,9 @@ public class DbFunctionRegister {
                 final int paramPosition = resultSet.getInt(i++);
                 final String paramName = resultSet.getString(i++);
                 final String paramType = resultSet.getString(i++);
-                final int procedureId = resultSet.getInt(i++);
+                final long procedureId = resultSet.getLong(i++);
                 final String paramTypeName = resultSet.getString(i++);
-                final int paramTypeId = resultSet.getInt(i++);
+                final long paramTypeId = resultSet.getLong(i++);
 
                 addFunctionParam(functionSchema, functionName, paramName, paramPosition, paramType, procedureId,
                     paramTypeName, paramTypeId);
@@ -85,8 +85,8 @@ public class DbFunctionRegister {
     }
 
     private void addFunctionParam(final String functionSchema, final String functionName, final String paramName,
-            final int paramPosition, final String paramType, final int procedureId, final String paramTypeName,
-            final int paramTypeId) {
+                                  final int paramPosition, final String paramType, final long procedureId, final String paramTypeName,
+                                  final long paramTypeId) {
 
         final String functionId = getFunctionIdentifier(functionSchema, functionName);
         DbFunction function = functions.get(functionId);

--- a/src/main/java/de/zalando/typemapper/core/db/DbType.java
+++ b/src/main/java/de/zalando/typemapper/core/db/DbType.java
@@ -8,10 +8,10 @@ public class DbType {
 
     private final String schema;
     private final String name;
-    private final int id;
+    private final long id;
     private Map<Integer, DbTypeField> fields = new HashMap<Integer, DbTypeField>();
 
-    public DbType(final String schema, final String name, final int id) {
+    public DbType(final String schema, final String name, final long id) {
         this.schema = schema;
         this.name = name;
         this.id = id;
@@ -25,7 +25,7 @@ public class DbType {
         return name;
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 

--- a/src/main/java/de/zalando/typemapper/core/db/DbTypeField.java
+++ b/src/main/java/de/zalando/typemapper/core/db/DbTypeField.java
@@ -6,10 +6,10 @@ public class DbTypeField {
     private final int position;
     private final String type;
     private final String typeName;
-    private final int typeId;
+    private final long typeId;
 
     public DbTypeField(final String fieldName, final int fieldPosition, final String fieldType,
-            final String fieldTypeName, final int fieldTypeId) {
+            final String fieldTypeName, final long fieldTypeId) {
         this.name = fieldName;
         this.position = fieldPosition;
         this.type = fieldType;
@@ -33,7 +33,7 @@ public class DbTypeField {
         return typeName;
     }
 
-    public int getTypeId() {
+    public long getTypeId() {
         return typeId;
     }
 

--- a/src/main/java/de/zalando/typemapper/core/db/DbTypeRegister.java
+++ b/src/main/java/de/zalando/typemapper/core/db/DbTypeRegister.java
@@ -36,7 +36,7 @@ public class DbTypeRegister {
 
     private final Map<String, String> typeFQN;
 
-    private final Map<Integer, String> typeIdToFQN;
+    private final Map<Long, String> typeIdToFQN;
 
     public DbTypeRegister(final Connection connection) throws SQLException {
         PreparedStatement statement = null;
@@ -45,7 +45,7 @@ public class DbTypeRegister {
             searchPath = getSearchPath(connection);
             typeByName = new HashMap<String, DbType>();
 
-            typeIdToFQN = new ConcurrentHashMap<>();
+            typeIdToFQN = new ConcurrentHashMap<Long, String>();
 
             final HashMap<String, List<String>> typeNameToFQN = new HashMap<String, List<String>>();
 
@@ -81,7 +81,7 @@ public class DbTypeRegister {
                 int i = 1;
                 final String typeSchema = resultSet.getString(i++);
                 final String typeName = resultSet.getString(i++);
-                final int typeId = resultSet.getInt(i++);
+                final long typeId = resultSet.getLong(i++);
                 final String typeType = resultSet.getString(i++);
                 final String fieldName = resultSet.getString(i++);
                 final String fieldType = resultSet.getString(i++);
@@ -123,10 +123,10 @@ public class DbTypeRegister {
         return typeByName;
     }
 
-    private void addField(final String typeSchema, final String typeName, final int typeId, final String fieldName,
-            final int fieldPosition, final String fieldType, final String fieldTypeName, final int fieldTypeId,
-            final String typeType, final boolean isArray, final Map<String, List<String>> typeNameToFQN,
-            final int typeElem) {
+    private void addField(final String typeSchema, final String typeName, final long typeId, final String fieldName,
+                          final int fieldPosition, final String fieldType, final String fieldTypeName, final int fieldTypeId,
+                          final String typeType, final boolean isArray, final Map<String, List<String>> typeNameToFQN,
+                          final int typeElem) {
 
         if (isArray) {
 
@@ -210,7 +210,7 @@ public class DbTypeRegister {
         return fqName == null ? null : register.typeByName.get(fqName);
     }
 
-    public static DbType getDbType(final int id, final Connection connection) throws SQLException {
+    public static DbType getDbType(final long id, final Connection connection) throws SQLException {
         final DbTypeRegister register = getRegistry(connection);
         DbType type = null;
 
@@ -241,7 +241,7 @@ public class DbTypeRegister {
                     PreparedStatement ps = null;
                     try {
                         ps = connection.prepareStatement(sql);
-                        ps.setInt(1, id);
+                        ps.setLong(1, id);
                         res = ps.executeQuery();
                         if (res.next()) {
                             typeFQN = getTypeIdentifier(res.getString(1), res.getString(2));

--- a/src/main/java/de/zalando/typemapper/core/db/DbTypeRegister.java
+++ b/src/main/java/de/zalando/typemapper/core/db/DbTypeRegister.java
@@ -86,7 +86,7 @@ public class DbTypeRegister {
                 final String fieldName = resultSet.getString(i++);
                 final String fieldType = resultSet.getString(i++);
                 final String fieldTypeName = resultSet.getString(i++);
-                final int fieldTypeId = resultSet.getInt(i++);
+                final long fieldTypeId = resultSet.getLong(i++);
                 final int fieldPosition = resultSet.getInt(i++);
                 final boolean isArray = resultSet.getBoolean(i++);
                 final int typeElem = resultSet.getInt(i++);
@@ -124,7 +124,7 @@ public class DbTypeRegister {
     }
 
     private void addField(final String typeSchema, final String typeName, final long typeId, final String fieldName,
-                          final int fieldPosition, final String fieldType, final String fieldTypeName, final int fieldTypeId,
+                          final int fieldPosition, final String fieldType, final String fieldTypeName, final long fieldTypeId,
                           final String typeType, final boolean isArray, final Map<String, List<String>> typeNameToFQN,
                           final int typeElem) {
 

--- a/src/main/java/de/zalando/typemapper/core/result/ArrayResultNode.java
+++ b/src/main/java/de/zalando/typemapper/core/result/ArrayResultNode.java
@@ -15,11 +15,11 @@ public class ArrayResultNode implements DbResultNode {
 
     private String name;
     private String type;
-    private int typeId;
+    private long typeId;
     private List<DbResultNode> children;
     private DbType typeDef;
 
-    public ArrayResultNode(final String name, final String value, final String typeName, final int typeId,
+    public ArrayResultNode(final String name, final String value, final String typeName, final long typeId,
             final Connection connection) throws SQLException {
         this.name = name;
         this.type = typeName;

--- a/src/main/java/de/zalando/typemapper/core/result/ObjectResultNode.java
+++ b/src/main/java/de/zalando/typemapper/core/result/ObjectResultNode.java
@@ -23,11 +23,11 @@ public class ObjectResultNode implements DbResultNode {
 
     private String name;
     private String type;
-    private int typeId;
+    private long typeId;
     private List<DbResultNode> children;
     private Map<String, DbResultNode> nodeMap = new HashMap<>();
 
-    public ObjectResultNode(final String value, final String name, final String typeName, final int typeId,
+    public ObjectResultNode(final String value, final String name, final String typeName, final long typeId,
             final Connection connection) throws SQLException {
         super();
         this.type = typeName;


### PR DESCRIPTION
https://www.postgresql.org/docs/11/datatype-oid.html says:

> The oid type is currently implemented as an unsigned four-byte integer.

That is, its minimum value is 0, maximum is 4294967295 (2^32 - 1).  In DBs with a long enough history we might experience OIDs that exceed the Java `int` range, resulting in something like:

```nested exception is org.springframework.dao.DataIntegrityViolationException: PreparedStatementCallback; SQL [SELECT * FROM 
some_function_with_custom_type_argument (  )]; Bad value for type int : 2149535750; nested exception is org.postgresql.util.PSQLException: Bad value for type int : 2149535750
        at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:298)
        ... 7 more```