### PR TITLE
Fix timezones for inserts.

### DIFF
--- a/src/test/java/org/zalando/typemapper/AbstractTest.java
+++ b/src/test/java/org/zalando/typemapper/AbstractTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractTest {
 
         execute("CREATE TABLE tmp.test_time(lt timestamp without time zone, gt timestamp with time zone, zone text);");
         execute(
-            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00+0' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00+2' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00+2' AT TIME ZONE 'UTC', '2012-08-01 04:00:00+09', 'japan');");
+            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-25 16:00:00+0' AT TIME ZONE 'UTC', '2012-07-25 16:00:00+0', 'utc'), ('2012-07-26 16:00:00+0' AT TIME ZONE 'UTC', '2012-07-26 18:00:00+2', 'cest'), ('2012-07-29 19:00:00+0' AT TIME ZONE 'UTC', '2012-07-30 04:00:00+09', 'japan');");
 
         final String test_time_sproc =
             "CREATE OR REPLACE FUNCTION tmp.test_time_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "

--- a/src/test/java/org/zalando/typemapper/AbstractTest.java
+++ b/src/test/java/org/zalando/typemapper/AbstractTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractTest {
 
         execute("CREATE TABLE tmp.test_time(lt timestamp without time zone, gt timestamp with time zone, zone text);");
         execute(
-            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00' AT TIME ZONE 'UTC', '2012-08-01 04:00:00-09', 'japan');");
+            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00' AT TIME ZONE 'UTC', '2012-08-01 04:00:00+09', 'japan');");
 
         final String test_time_sproc =
             "CREATE OR REPLACE FUNCTION tmp.test_time_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "

--- a/src/test/java/org/zalando/typemapper/AbstractTest.java
+++ b/src/test/java/org/zalando/typemapper/AbstractTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractTest {
 
         execute("CREATE TABLE tmp.test_time(lt timestamp without time zone, gt timestamp with time zone, zone text);");
         execute(
-            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00', '2012-07-30 14:00:00+0', 'utc'), ('2012-07-30 18:00:00', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 21:00:00', '2012-07-30 10:00:00-09', 'japan');");
+            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'CEST', '2012-07-30 14:00:00+0', 'utc'), ('2012-07-30 18:00:00' AT TIME ZONE 'CEST', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 21:00:00' AT TIME ZONE 'CEST', '2012-07-30 10:00:00-09', 'japan');");
 
         final String test_time_sproc =
             "CREATE OR REPLACE FUNCTION tmp.test_time_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "

--- a/src/test/java/org/zalando/typemapper/AbstractTest.java
+++ b/src/test/java/org/zalando/typemapper/AbstractTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractTest {
 
         execute("CREATE TABLE tmp.test_time(lt timestamp without time zone, gt timestamp with time zone, zone text);");
         execute(
-            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'CEST', '2012-07-30 14:00:00+0', 'utc'), ('2012-07-30 18:00:00' AT TIME ZONE 'CEST', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 21:00:00' AT TIME ZONE 'CEST', '2012-07-30 10:00:00-09', 'japan');");
+            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00' AT TIME ZONE 'UTC', '2012-08-01 04:00:00-09', 'japan');");
 
         final String test_time_sproc =
             "CREATE OR REPLACE FUNCTION tmp.test_time_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "

--- a/src/test/java/org/zalando/typemapper/AbstractTest.java
+++ b/src/test/java/org/zalando/typemapper/AbstractTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractTest {
 
         execute("CREATE TABLE tmp.test_time(lt timestamp without time zone, gt timestamp with time zone, zone text);");
         execute(
-            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00' AT TIME ZONE 'UTC', '2012-08-01 04:00:00+09', 'japan');");
+            "INSERT INTO tmp.test_time(lt, gt, zone) VALUES ('2012-07-30 16:00:00+0' AT TIME ZONE 'UTC', '2012-07-30 16:00:00+0', 'utc'), ('2012-07-30 16:00:00+2' AT TIME ZONE 'UTC', '2012-07-30 18:00:00+2', 'cest'), ('2012-07-30 19:00:00+2' AT TIME ZONE 'UTC', '2012-08-01 04:00:00+09', 'japan');");
 
         final String test_time_sproc =
             "CREATE OR REPLACE FUNCTION tmp.test_time_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "

--- a/src/test/java/org/zalando/typemapper/namedresult/DateTimeTestIT.java
+++ b/src/test/java/org/zalando/typemapper/namedresult/DateTimeTestIT.java
@@ -22,7 +22,7 @@ public class DateTimeTestIT extends AbstractTest {
 
     @Test
     public void testDateTimeMappings() throws SQLException {
-        final PreparedStatement ps = connection.prepareStatement("SELECT lt, gt, zone from tmp.test_time");
+        final PreparedStatement ps = connection.prepareStatement("SELECT (lt AT TIME ZONE 'UTC')::timestamp lt, gt, zone from tmp.test_time");
         final ResultSet rs = ps.executeQuery();
         final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithDateTime.class);
         int i = 0;


### PR DESCRIPTION
Pin test data inserted properly at UTC and also generate a query that reads properly UTC for the non time zone column. Only this way I believe this can work locally and remote where CEST and UTCs are used and Postgres potentially has its own TZ set.