### PR TITLE
update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ You can find some more information about the SProcWrapper in our various Zalando
 * http://tech.zalando.com/blog/zalando-stored-procedure-wrapper-part-i/
 * http://tech.zalando.com/blog/files/2013/04/jug_dortmund_april_2013.pdf
 
+🚨 Upgrading from 2.x to 3.x? Please be aware that default scanning package for custom objectTransformer has changed from `de.zalando` to `org.zalando`.
+
 ## Contributing
 
 See [contributing guideline](CONTRIBUTING.md).


### PR DESCRIPTION
@vadeg We should inform users that they need to move their custom objectTransformer to the new default package, or they need to provide scanning namespace instead of supporting the old namespace ("de.zalando") ( https://github.com/zalando-stups/java-sproc-wrapper/pull/68)

It is solution for https://github.com/zalando-stups/java-sproc-wrapper/issues/67