### PR TITLE
Add multi packages support in `GlobalValueTransformerLoader`

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,10 +1,19 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Add support of multiple packages in `global.value.transformer.search.namespace` configuration property using `;`
+  separator, e.g. `a.b.c;x.y.z`.
+- Update `reflections` library version to `0.9.12` 
+
+## [3.0.0] - 2021-01-07
 
 ### Changed
 
@@ -16,14 +25,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.0.0] - 2017-08-04
 
 ### Added
+
 - Changelog
 - Contribution guide
 
 ### Changed
+
 - Updated to Java 8
 - Updated Spring version to `4.3.8.RELEASE`
 - Postgresql JDBC driver updated to version `42.1.1`
 - Project license changed to [MIT](LICENSE).
 
 ### Removed
+
 - Java 7 support 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
+            <version>0.9.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/org/zalando/sprocwrapper/globalvaluetransformer/GlobalValueTransformerLoader.java
+++ b/src/main/java/org/zalando/sprocwrapper/globalvaluetransformer/GlobalValueTransformerLoader.java
@@ -1,49 +1,38 @@
 package org.zalando.sprocwrapper.globalvaluetransformer;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.reflections.Reflections;
-
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
-
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-
 import org.zalando.sprocwrapper.globalvaluetransformer.annotation.GlobalValueTransformer;
-
 import org.zalando.typemapper.core.ValueTransformer;
 import org.zalando.typemapper.core.fieldMapper.GlobalValueTransformerRegistry;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 public class GlobalValueTransformerLoader {
 
-    private static final String GLOBAL_VALUE_TRANSFORMER_SEARCH_NAMESPACE = "global.value.transformer.search.namespace";
-
-    // you need to set the namespace to a valid value like: org.doodlejump
-    private static String namespaceToScan = "org.zalando";
-
     private static final Logger LOG = LoggerFactory.getLogger(GlobalValueTransformerLoader.class);
+    private static final String GLOBAL_VALUE_TRANSFORMER_SEARCH_NAMESPACE = "global.value.transformer.search.namespace";
+    private static final String NAMESPACE_SEPARATOR = ";";
+    private static String namespaceToScan = "org.zalando";
     private static boolean scannedClasspath = false;
 
     public static synchronized ValueTransformer<?, ?> getValueTransformerForClass(final Class<?> genericType)
-        throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+            throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
 
         // did we already scanned the classpath for global value transformers?
-        if (scannedClasspath == false) {
-            final Predicate<String> filter = new Predicate<String>() {
-                @Override
-                public boolean apply(final String input) {
-                    return GlobalValueTransformer.class.getCanonicalName().equals(input);
-                }
-            };
+        if (!scannedClasspath) {
 
             // last to get the namespace from the system environment
             String myNameSpaceToScan = null;
@@ -59,29 +48,33 @@ public class GlobalValueTransformerLoader {
                 myNameSpaceToScan = namespaceToScan;
             }
 
-            if (!Strings.isNullOrEmpty(myNameSpaceToScan)) {
-                final Reflections reflections = new Reflections(new ConfigurationBuilder().filterInputsBy(
-                            new FilterBuilder.Include(FilterBuilder.prefix(myNameSpaceToScan))).setUrls(
-                            ClasspathHelper.forPackage(myNameSpaceToScan)).setScanners(new TypeAnnotationsScanner()
-                                .filterResultsBy(filter), new SubTypesScanner()));
-                final Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(
-                        GlobalValueTransformer.class);
-                for (final Class<?> foundGlobalValueTransformer : typesAnnotatedWith) {
-                    final Class<?> valueTransformerReturnType;
-                    try {
-                        valueTransformerReturnType = ValueTransformerUtils.getUnmarshalFromDbClass(
-                                foundGlobalValueTransformer);
-                        GlobalValueTransformerRegistry.register(valueTransformerReturnType,
-                            (ValueTransformer<?, ?>) foundGlobalValueTransformer.getDeclaredConstructor().newInstance());
-                    } catch (final RuntimeException e) {
-                        LOG.error("Failed to add global transformer [{}] to global registry.",
-                            foundGlobalValueTransformer, e);
-                        continue;
-                    }
+            final Set<String> namespaces =
+                    Arrays.stream(myNameSpaceToScan.split(NAMESPACE_SEPARATOR))
+                          .map(String::trim)
+                          .filter(Strings::isNullOrEmpty)
+                          .collect(Collectors.toSet());
 
-                    LOG.debug("Global Value Transformer [{}] for type [{}] registered. ",
-                        foundGlobalValueTransformer.getSimpleName(), valueTransformerReturnType.getSimpleName());
+            namespaces.add(namespaceToScan);
+            LOG.debug("Scan the following packages for {}: {}", GlobalValueTransformer.class.getSimpleName(),
+                    namespaces);
+            final Set<Class<?>> typesAnnotatedWith = loadAnnotatedTypes(namespaces);
+
+            for (final Class<?> foundGlobalValueTransformer : typesAnnotatedWith) {
+                final Class<?> valueTransformerReturnType;
+                try {
+                    valueTransformerReturnType = ValueTransformerUtils.getUnmarshalFromDbClass(
+                            foundGlobalValueTransformer);
+                    GlobalValueTransformerRegistry.register(valueTransformerReturnType,
+                            (ValueTransformer<?, ?>) foundGlobalValueTransformer.getDeclaredConstructor()
+                                                                                .newInstance());
+                } catch (final RuntimeException e) {
+                    LOG.error("Failed to add global transformer [{}] to global registry.",
+                            foundGlobalValueTransformer, e);
+                    continue;
                 }
+
+                LOG.debug("Global Value Transformer [{}] for type [{}] registered.",
+                        foundGlobalValueTransformer.getSimpleName(), valueTransformerReturnType.getSimpleName());
             }
 
             scannedClasspath = true;
@@ -90,10 +83,26 @@ public class GlobalValueTransformerLoader {
         return GlobalValueTransformerRegistry.getValueTransformerForClass(genericType);
     }
 
+    private static Set<Class<?>> loadAnnotatedTypes(Set<String> namespacesToScan) {
+        final Predicate<String> filter = input -> GlobalValueTransformer.class.getCanonicalName().equals(input);
+        final Set<Class<?>> result = new HashSet<>();
+        for (String namespace : namespacesToScan) {
+            final Reflections reflections = new Reflections(
+                    new ConfigurationBuilder()
+                            .filterInputsBy(new FilterBuilder.Include(FilterBuilder.prefix(namespace)))
+                            .setUrls(ClasspathHelper.forPackage(namespace))
+                            .setScanners(new TypeAnnotationsScanner().filterResultsBy(filter),
+                                    new SubTypesScanner())
+            );
+            result.addAll(reflections.getTypesAnnotatedWith(GlobalValueTransformer.class));
+        }
+        return result;
+    }
+
     /**
      * Use this static function to set the namespace to scan.
      *
-     * @param  newNamespace  the new namespace to be searched for {@link GlobalValueTransformer}
+     * @param newNamespace the new namespace to be searched for {@link org.zalando.sprocwrapper.globalvaluetransformer.annotation.GlobalValueTransformer}
      */
     public static void changeNamespaceToScan(final String newNamespace) {
         namespaceToScan = newNamespace;


### PR DESCRIPTION
* `GlobalValueTransformerLoader` supports multi packages definition using `;`. For example `a.b.c;a.b.d`. The `org.zalando` package is always scanned, because it provides a `UUIDTransformer` as a part of the library.

* Update `reflections` version.
Related to #67 and #84 